### PR TITLE
bug:(globalContext) fixed the reducer function and added helper function in initial state and in global context

### DIFF
--- a/src/context/GlobalContext.tsx
+++ b/src/context/GlobalContext.tsx
@@ -2,14 +2,15 @@ import React, {useReducer, useEffect, createContext} from 'react';
 import instance from '../api/apiConfig'
 
 const initialState = {
-    drinks: []
+    drinks: [],
+    getDrinks: () =>{}
 };
 
 const appReducer = (action:any, state:any) => {
     switch (action.type) {
         case 'GET_PRODUCTS':
           // when a case matches, the return will update the state for us
-          return { ...state, products: action.payload, is_loading: false };
+          return { ...state, drinks: action.payload};
 
 }
 
@@ -44,10 +45,12 @@ export const GlobalProvider: React.FC = ({children}) =>{
     return (
         <GlobalContext.Provider 
         value={{
-             drinks: state.drinks
+             drinks: state.drinks,
+             getDrinks
         }}
         >
             {children}
         </GlobalContext.Provider>
     )
-}
+
+    }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -55,6 +55,7 @@ type Drinks = {
 
 type InitialState = {
     drinks: Drinks[];
+    getDrinks: () => void;
 }
 
 // {


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added helper function in types global file and in the initial state 
2. changed the reducer function by adding the correct state

## Purpose

- The helper which fetched the api needs to passed in the context provider so the children components can have access to the helper function and the reducer function needed correct data. 


Closes #17 
