### PR TITLE
feat(spinner): added spinner functionality inside the global context destructured it out inn the single page and created a conditional around on whether it should be display in the single card file

### DIFF
--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -1,0 +1,14 @@
+const Loader = () => {
+    return (
+      <div className='row text-center mt-5'>
+        <div className='col'>
+          <div className='spinner-border text-dark' role='status'>
+            {/* <span className='sr-only'>Loading...</span> */}
+          </div>
+          <h3>Loading...</h3>
+        </div>
+      </div>
+    );
+  };
+  
+  export default Loader;

--- a/src/components/SinglePageCard.tsx
+++ b/src/components/SinglePageCard.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import '../App.css';
+import Loader from '../components/Loader';
+
+
 
 interface SingleDrink{
   drinkInfo: Drinks;
+  loading: boolean;
 }
 
-const SingleCardDrink : React.FC <SingleDrink> = ({drinkInfo}) =>{
+const SingleCardDrink : React.FC <SingleDrink> = ({drinkInfo, loading}) =>{
+
+    if (loading) {
+        return <Loader />;
+      }
+    
    console.log(drinkInfo)
     return(
         <div className="card d-flex bg-dark my-4 col w-70 justify-content-between text-center text-white">

--- a/src/context/GlobalContext.tsx
+++ b/src/context/GlobalContext.tsx
@@ -19,7 +19,10 @@ const appReducer = (state:any, action:any) => {
             return { ...state, drinks: action.payload};
         case 'GET_PRODUCT':
           // when a case matches, the return will update the state for us
-            return { ...state, drink: action.payload};
+            return { ...state, drink: action.payload, loading: false};
+        case 'SPINNER_LOADING':
+          // when a case matches, the return will update the state for us
+            return { ...state, loading: action.payload};
         default:
             return state;
     }
@@ -30,15 +33,13 @@ export const GlobalContext = createContext<InitialState>(initialState);
 export const GlobalProvider: React.FC = ({children}) =>{
 
     const [state, dispatch] = useReducer(appReducer, initialState);
-    const [loading, setLoading] = useState(false);
+    const [localLoading, setLocalLoading] = useState(false);
 
 
     const getDrinks = async() =>{
-        // setLoading(true);
         try{
             let {data} = await instance.get('/api/json/v1/1/search.php?s=')
             console.log('the data:',data)            
-            // setLoading(false);
             dispatch({type: 'GET_PRODUCTS', payload: data.drinks})
 
 
@@ -49,11 +50,12 @@ export const GlobalProvider: React.FC = ({children}) =>{
 
     }
     const getSingleDrink = async(id:number) =>{
-        // setLoading(true);
+        setLocalLoading(true);
+
+        dispatch({type:'SPINNER_LOADING', payload:true})
         try{
             let {data} = await instance.get(`/api/json/v1/1/lookup.php?i=${id}`)
-            console.log('the data:',data)            
-            // setLoading(false);
+                    
             dispatch({type: 'GET_PRODUCT', payload: data.drinks})
 
 
@@ -74,7 +76,7 @@ export const GlobalProvider: React.FC = ({children}) =>{
              drink: state.drink,
              getDrinks,
              getSingleDrink,
-             loading
+             loading: state.loading
         }}
         >
             {children}

--- a/src/pages/Singlepage.tsx
+++ b/src/pages/Singlepage.tsx
@@ -4,7 +4,7 @@ import {useParams} from 'react-router-dom';
 import SingleCardDrink from '../components/SinglePageCard';
 
 const SinglePage = () =>{
-    const {getSingleDrink, drink} = useContext(GlobalContext);
+    const {getSingleDrink, drink,loading} = useContext(GlobalContext);
 
     const {cocktailId} = useParams<{cocktailId: string}>();
 
@@ -18,7 +18,7 @@ const SinglePage = () =>{
         <div>
            {drink.map((drinkInfo, i) =>{
                return (
-                <SingleCardDrink key={i} drinkInfo ={drinkInfo}/>
+                <SingleCardDrink key={i} drinkInfo ={drinkInfo} loading={loading}/>
                )         
            })}
         </div>


### PR DESCRIPTION

## Changes
_List Changes Introduced by this PR_
1. created spinner folder and file
2. imported it into single page file 
3. created functionality inside the Global context file with the help of reducer

## Purpose

- The spinner is displayed while api response comes back 

## Approach

- There is not an weird lag  before the api data  is sent back. 

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #25 
